### PR TITLE
fix(source-all.sh): Allow scripts to return non-zero exit codes in `bash -e` environment

### DIFF
--- a/source-all.sh
+++ b/source-all.sh
@@ -14,5 +14,8 @@ source "$dir"/lib/fun.sh
 
 for script in "$dir"/sources/* ; do
   # shellcheck disable=SC1090
-  source "$script"
+  # NOTE: `|| true` is needed because some scripts (e.g., nvim-parent-edit.sh)
+  # may return 1 when required environment variables are not set.
+  # This allows source-all.sh to work correctly with `bash -e` (set -e).
+  source "$script" || true
 done


### PR DESCRIPTION
## Summary

- `source-all.sh`が`bash -e`環境（GitHub Actionsの`run:`ブロック等）で正しく動作するように修正
- `nvim-parent-edit.sh`のように特定の環境変数が設定されていない場合に`return 1`を返すスクリプトがあっても、全体が停止しなくなった

## Test plan

- [x] ローカルで`bash -e -c 'source ./source-all.sh && echo SUCCESS'`が成功することを確認
- [x] ローカルで`./run-tests.sh`が正常に走ることを確認
- [x] CIでテストが正常に走ることを確認