### PR TITLE
feat(bin > pomodoro-cycle): Add `pomodoro-cycle` command

### DIFF
--- a/.github/workflows/test-pomodoro-cycle.yml
+++ b/.github/workflows/test-pomodoro-cycle.yml
@@ -1,0 +1,30 @@
+name: Test pomodoro-cycle
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'bin/pomodoro-cycle'
+      - 'test/pomodoro-cycle.bats'
+      - 'lib/**'
+      - 'sources/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'bin/pomodoro-cycle'
+      - 'test/pomodoro-cycle.bats'
+      - 'lib/**'
+      - 'sources/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize submodules
+        run: git submodule update --init --recursive
+      - name: Run test
+        run: |
+          source ./source-all.sh
+          ./lib/bats/bin/bats ./test/pomodoro-cycle.bats

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ These dependencies are documented at the beginning of the script.
 | [`pathshorten`](./bin/pathshorten) | Abbreviate file path with shortened parent directories | `$ pathshorten ~/Documents/Proj # => ~/Docu/Proj` | ![No Test](https://img.shields.io/badge/Test-N%2FA-lightgray) |
 | [`peco-reverse`](./bin/peco-reverse) | Reverse order interactive filter using peco | `$ ls \| peco-reverse # reversed filter` | ![No Test](https://img.shields.io/badge/Test-N%2FA-lightgray) |
 | [`photoframe`](./bin/photoframe) | Display photos in fullscreen slideshow mode using feh | `$ photoframe ~/Pictures # slideshow` | ![No Test](https://img.shields.io/badge/Test-N%2FA-lightgray) |
+| [`pomodoro-cycle`](./bin/pomodoro-cycle) | Run a full pomodoro cycle with multiple work sessions and breaks | `$ pomodoro-cycle 3 25 25 25 # 3x25min cycle` | [![Test](https://github.com/aiya000/bash-toys/actions/workflows/test-pomodoro-cycle.yml/badge.svg)](https://github.com/aiya000/bash-toys/actions/workflows/test-pomodoro-cycle.yml) |
 | [`pomodoro-timer`](./bin/pomodoro-timer) | A simplest Pomodoro Timer implementation in shell script | `$ pomodoro-timer 25 # start 25min` | [![Test](https://github.com/aiya000/bash-toys/actions/workflows/test-pomodoro-timer.yml/badge.svg)](https://github.com/aiya000/bash-toys/actions/workflows/test-pomodoro-timer.yml) |
 | [`prompt`](./bin/prompt) | Display a prompt and wait for the user to press Enter (always exits 0) | `$ prompt 'Press Enter: ' # pause` | [![Test](https://github.com/aiya000/bash-toys/actions/workflows/test-prompt.yml/badge.svg)](https://github.com/aiya000/bash-toys/actions/workflows/test-prompt.yml) |
 | [`rm-dust`](./bin/rm-dust) | An alternative to `rm`, moving files to a dustbox instead. Use `--restore` to recover files. `alias rm=rm-dust` is recommended! | `$ rm-dust file.txt # mv to dustbox` | [![Test](https://github.com/aiya000/bash-toys/actions/workflows/test-dust.yml/badge.svg)](https://github.com/aiya000/bash-toys/actions/workflows/test-dust.yml) |
@@ -237,6 +238,14 @@ $ pomodoro-timer              # Default 30 minutes
 $ pomodoro-timer 25           # Classic 25-minute pomodoro
 $ pomodoro-timer --rest 5     # 5-minute break timer
 $ pomodoro-timer --from 09:30 60   # Resume timer that started at 09:30 for 60 minutes
+```
+
+**[`pomodoro-cycle`](./bin/pomodoro-cycle)** - Run a full multi-step Pomodoro cycle with breaks between sessions.
+
+```bash
+$ pomodoro-cycle              # 3 steps × 30 min (default)
+$ pomodoro-cycle 3 25 25 25   # Classic 3 × 25 min pomodoro
+$ pomodoro-cycle 2 45 30      # step 1: 45 min, step 2: 30 min
 ```
 
 <!-- }}} -->

--- a/bin/pomodoro-cycle
+++ b/bin/pomodoro-cycle
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# See ../doc/bin.md for description
+
+function show_help() {
+  cat << 'EOF'
+pomodoro-cycle - Run a full pomodoro cycle with multiple work sessions
+
+Usage:
+  pomodoro-cycle [--ntfy] [steps [time1 [time2 [time3]]]]
+  pomodoro-cycle -h | --help
+
+Arguments:
+  steps   Number of work steps in the cycle (default: 3)
+  time1   Duration of step 1 in minutes (default: 30)
+  time2   Duration of step 2 in minutes (default: 30)
+  time3   Duration of step 3 in minutes (default: 30)
+
+Options:
+  --ntfy          Send ntfy notification when cycle finishes
+  -h, --help      Show this help message
+
+Description:
+  Runs a sequence of pomodoro work sessions. Between each step, a break
+  timer starts and waits for the user to press Enter before continuing.
+  After the final step, sends a desktop notification. If --ntfy is
+  specified, also sends an ntfy notification.
+
+Examples:
+  pomodoro-cycle            # 3 steps of 30 minutes each
+  pomodoro-cycle 2          # 2 steps of 30 minutes each
+  pomodoro-cycle 3 25 25 25 # 3 steps of 25 minutes each
+  pomodoro-cycle 2 45 30    # step 1: 45 min, step 2: 30 min
+  pomodoro-cycle --ntfy     # 3 steps, with ntfy notification at the end
+EOF
+}
+
+[[ $1 == --help || $1 == -h ]] && show_help && exit 0
+
+# Parse --ntfy flag from args, leaving positional args intact
+use_ntfy=false
+args=()
+for arg in "$@"; do
+  if [[ $arg == --ntfy ]]; then
+    use_ntfy=true
+  else
+    args+=("$arg")
+  fi
+done
+set -- "${args[@]}"
+
+function pomodoro-start () {
+  local time is_last_step
+  time=${1:-30}
+  is_last_step=${2:-false}
+
+  pomodoro-timer "$time"
+
+  if [[ $is_last_step != true ]]; then
+    # Wait for the user to start the next step
+    pomodoro-timer --rest
+    prompt
+    return
+  fi
+
+  # Notify the end of the cycle
+  sleep 3
+  [[ $use_ntfy == true ]] && notify-ntfy pomodoro-cycle finished &
+  notify pomodoro-cycle finished ~/.dotfiles/bash-toys/assets/onepoint30.mp3 &
+}
+
+steps_in_cycle=${1:-3}
+time_in_step=("${2:-30}" "${3:-30}" "${4:-30}")
+
+echo "Start pomodoro cycle: $steps_in_cycle steps with [${time_in_step[*]}] minutes in each step"
+pomodoro-timer --clean
+echo
+
+for (( i = 0; i < $((steps_in_cycle - 1)); i++ )) ; do
+  pomodoro-start "${time_in_step[i]}"
+done
+pomodoro-start "${time_in_step[steps_in_cycle - 1]}" true # For the last step, skip `prompt` and notify the end of the cycle
+
+# https://github.com/aiya000/bash-toys
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2025- aiya000
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.

--- a/completions/pomodoro-cycle.bash
+++ b/completions/pomodoro-cycle.bash
@@ -7,7 +7,7 @@ _pomodoro_cycle_completion() {
   cur="${COMP_WORDS[COMP_CWORD]}"
 
   if [[ $cur == -* ]] ; then
-    COMPREPLY=($(compgen -W '--help -h' -- "$cur"))
+    COMPREPLY=($(compgen -W '--help -h --ntfy' -- "$cur"))
     return
   fi
 }

--- a/completions/pomodoro-cycle.bash
+++ b/completions/pomodoro-cycle.bash
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Bash completion for pomodoro-cycle command
+
+_pomodoro_cycle_completion() {
+  local cur
+  cur="${COMP_WORDS[COMP_CWORD]}"
+
+  if [[ $cur == -* ]] ; then
+    COMPREPLY=($(compgen -W '--help -h' -- "$cur"))
+    return
+  fi
+}
+
+complete -F _pomodoro_cycle_completion pomodoro-cycle
+
+# https://github.com/aiya000/bash-toys
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2025- aiya000
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.

--- a/doc/bin.md
+++ b/doc/bin.md
@@ -993,7 +993,7 @@ Enter to continue...
 
 # Run 2 steps of 45 minutes each
 $ pomodoro-cycle 2 45 45
-Start pomodoro cycle: 2 steps with [45 45 30] minutes in each step
+Start pomodoro cycle: 2 steps with [45 45] minutes in each step
 ...
 
 # Run 3 classic pomodoro steps (25 min each)

--- a/doc/bin.md
+++ b/doc/bin.md
@@ -957,6 +957,57 @@ $ pomodoro-timer --clean
 Removed: /tmp/pomodoro-3
 ```
 
+### pomodoro-cycle
+
+Runs a full pomodoro cycle with multiple work sessions.
+
+```bash
+pomodoro-cycle [--ntfy] [steps [time1 [time2 [time3]]]]
+```
+
+**Arguments**:
+- `steps` - Number of work steps in the cycle (default: `3`)
+- `time1`, `time2`, `time3` - Duration of each step in minutes (default: `30`)
+
+**Options**:
+- `--ntfy` - Send ntfy notification when cycle finishes (in addition to desktop notification)
+
+**Description**:
+
+Runs a sequence of pomodoro work sessions. Between each step (except the last), a break timer starts and then waits for the user to press Enter before continuing. After the final step, sends a desktop notification. If `--ntfy` is specified, also sends an ntfy notification.
+
+**Examples**:
+```bash
+# Run 3 steps of 30 minutes each (default)
+$ pomodoro-cycle
+Start pomodoro cycle: 3 steps with [30 30 30] minutes in each step
+
+> Starting 1-th work time
+> 1 minutes / 30
+...
+> The 1-th work hour is over
+> Starting break time
+...
+> Now it's time to get to work
+Enter to continue...
+
+# Run 2 steps of 45 minutes each
+$ pomodoro-cycle 2 45 45
+Start pomodoro cycle: 2 steps with [45 45 30] minutes in each step
+...
+
+# Run 3 classic pomodoro steps (25 min each)
+$ pomodoro-cycle 3 25 25 25
+Start pomodoro cycle: 3 steps with [25 25 25] minutes in each step
+...
+
+# With ntfy notification at the end
+$ pomodoro-cycle --ntfy 3 25 25 25
+Start pomodoro cycle: 3 steps with [25 25 25] minutes in each step
+...
+# (ntfy notification sent after final step)
+```
+
 ### date-diff-seconds
 
 Calculates time difference in minutes.

--- a/test/pomodoro-cycle.bats
+++ b/test/pomodoro-cycle.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+
+# shellcheck disable=SC2016
+
+setup() {
+  # Ensure we use commands from this repository, not from PATH
+  export PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
+
+  # Create temp dir for mock commands (prepend to PATH to override real commands)
+  MOCK_DIR="$(mktemp -d)"
+  export PATH="$MOCK_DIR:$PATH"
+
+  # Mock pomodoro-timer to record calls without sleeping
+  cat > "$MOCK_DIR/pomodoro-timer" << 'EOF'
+#!/bin/bash
+echo "pomodoro-timer $*"
+EOF
+  chmod +x "$MOCK_DIR/pomodoro-timer"
+
+  # Mock prompt to avoid blocking on input
+  cat > "$MOCK_DIR/prompt" << 'EOF'
+#!/bin/bash
+echo "prompt $*"
+EOF
+  chmod +x "$MOCK_DIR/prompt"
+
+  # Mock notify and notify-ntfy to avoid side effects
+  cat > "$MOCK_DIR/notify" << 'EOF'
+#!/bin/bash
+echo "notify $*"
+EOF
+  chmod +x "$MOCK_DIR/notify"
+
+  cat > "$MOCK_DIR/notify-ntfy" << 'EOF'
+#!/bin/bash
+echo "notify-ntfy $*"
+EOF
+  chmod +x "$MOCK_DIR/notify-ntfy"
+
+  # Mock sleep to avoid waiting in the final step
+  cat > "$MOCK_DIR/sleep" << 'EOF'
+#!/bin/bash
+echo "sleep $*"
+EOF
+  chmod +x "$MOCK_DIR/sleep"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+}
+
+# --- Help ---
+
+@test '`pomodoro-cycle --help` should show help message' {
+  run pomodoro-cycle --help
+  expects "$status" to_be 0
+  expects "${lines[0]}" to_match '^pomodoro-cycle - '
+}
+
+@test '`pomodoro-cycle -h` should show help message' {
+  run pomodoro-cycle -h
+  expects "$status" to_be 0
+  expects "${lines[0]}" to_match '^pomodoro-cycle - '
+}
+
+@test '`pomodoro-cycle --help` should show usage and examples' {
+  run pomodoro-cycle --help
+  expects "$status" to_be 0
+  expects "$output" to_contain 'Usage:'
+  expects "$output" to_contain 'Examples:'
+}
+
+# --- Output header ---
+
+@test '`pomodoro-cycle` should show 3 steps with 30 min each by default' {
+  run pomodoro-cycle
+  expects "$status" to_be 0
+  expects "${lines[0]}" to_match 'Start pomodoro cycle: 3 steps with \[30 30 30\] minutes in each step'
+}
+
+@test '`pomodoro-cycle` should show custom step count in header' {
+  run pomodoro-cycle 2
+  expects "$status" to_be 0
+  expects "${lines[0]}" to_match 'Start pomodoro cycle: 2 steps'
+}
+
+@test '`pomodoro-cycle` should show custom times in header' {
+  run pomodoro-cycle 3 25 25 25
+  expects "$status" to_be 0
+  expects "${lines[0]}" to_match 'Start pomodoro cycle: 3 steps with \[25 25 25\] minutes in each step'
+}
+
+# --- Timer calls ---
+
+@test '`pomodoro-cycle` should call `pomodoro-timer --clean` at the start' {
+  run pomodoro-cycle 1
+  expects "$status" to_be 0
+  expects "$output" to_contain 'pomodoro-timer --clean'
+}
+
+@test '`pomodoro-cycle` should call work timer for each step with correct time' {
+  run pomodoro-cycle 2 45 20
+  expects "$status" to_be 0
+  expects "$output" to_contain 'pomodoro-timer 45'
+  expects "$output" to_contain 'pomodoro-timer 20'
+}
+
+@test '`pomodoro-cycle` should call rest timer and prompt between steps' {
+  run pomodoro-cycle 2
+  expects "$status" to_be 0
+  expects "$output" to_contain 'pomodoro-timer --rest'
+  expects "$output" to_contain 'prompt'
+}
+
+@test '`pomodoro-cycle` should NOT call rest timer after the last step' {
+  run pomodoro-cycle 1
+  expects "$status" to_be 0
+  expects "$output" not to_contain 'pomodoro-timer --rest'
+  expects "$output" not to_contain 'prompt'
+}
+
+@test '`pomodoro-cycle` should send desktop notification after the last step' {
+  run pomodoro-cycle 1
+  expects "$status" to_be 0
+  expects "$output" to_contain 'notify pomodoro-cycle finished'
+}
+
+@test '`pomodoro-cycle` should NOT send ntfy notification without --ntfy' {
+  run pomodoro-cycle 1
+  expects "$status" to_be 0
+  expects "$output" not to_contain 'notify-ntfy'
+}
+
+@test '`pomodoro-cycle --ntfy` should send ntfy notification after the last step' {
+  run pomodoro-cycle --ntfy 1
+  expects "$status" to_be 0
+  expects "$output" to_contain 'notify-ntfy pomodoro-cycle finished'
+  expects "$output" to_contain 'notify pomodoro-cycle finished'
+}
+
+@test '`pomodoro-cycle --ntfy` should still use positional args correctly' {
+  run pomodoro-cycle --ntfy 2 45 20
+  expects "$status" to_be 0
+  expects "${lines[0]}" to_match 'Start pomodoro cycle: 2 steps with \[45 20'
+}


### PR DESCRIPTION
## Summary

- Add new `pomodoro-cycle` command that orchestrates multiple pomodoro work sessions in sequence
- Supports `--ntfy` flag to optionally send ntfy notification after the final step

## Changes

- `bin/pomodoro-cycle`: New command with `--help`, `--ntfy` flag, and MIT license
- `test/pomodoro-cycle.bats`: 14 tests with mocked dependencies (pomodoro-timer, prompt, notify, sleep)
- `completions/pomodoro-cycle.bash`: Bash completion for `--help`, `-h`, `--ntfy`
- `.github/workflows/test-pomodoro-cycle.yml`: CI workflow triggered on changes to the command and its test
- `doc/bin.md`: New section documenting arguments, options, and examples
- `README.md`: Added row to script table and entry in Notifications & Timers section