### PR TITLE
feat(sources): Add `zsh-vi-flash-find` -- flash.nvim-compatible `f`/`F`/`t`/`T` repeat for zsh vi-mode

### DIFF
--- a/doc/sources.md
+++ b/doc/sources.md
@@ -278,11 +278,15 @@ zsh-vi-flash-find-setup
 
 After setup, pressing the same motion key consecutively repeats the find motion,
 matching the behavior of [flash.nvim](https://github.com/folke/flash.nvim).
+Pressing the counterpart key (`f` after `F`, or `F` after `f`) reverses direction.
+Any non-f/F/t/T keypress in between resets the sequence (next press starts a new search).
 
 **Usage**:
 - `fafff` → find `a`, then repeat twice (equivalent to `fa;;`)
 - `FaFFF` → find `a` backwards, then repeat twice
+- `faFF`  → find `a` forward, then reverse twice (equivalent to `fa,,`)
 - `tabt`  → move before `b`, then repeat
+- `faf0f` → find `a`, repeat once, press `0` to jump to line start, then `f` starts a fresh search
 
 **Setup** (in `.zshrc`, after `bindkey -v`):
 ```bash

--- a/doc/sources.md
+++ b/doc/sources.md
@@ -266,6 +266,33 @@ load-my-env docker    # Sets up docker aliases
 load-my-env nvm       # Loads nvm
 ```
 
+## ZSH Vi-Mode
+
+### zsh-vi-flash-find
+
+Enables flash.nvim-compatible `f`/`F`/`t`/`T` repeat in zsh vi-mode.
+
+```bash
+zsh-vi-flash-find-setup
+```
+
+After setup, pressing the same motion key consecutively repeats the find motion,
+matching the behavior of [flash.nvim](https://github.com/folke/flash.nvim).
+
+**Usage**:
+- `fafff` → find `a`, then repeat twice (equivalent to `fa;;`)
+- `FaFFF` → find `a` backwards, then repeat twice
+- `tabt`  → move before `b`, then repeat
+
+**Setup** (in `.zshrc`, after `bindkey -v`):
+```bash
+bindkey -v
+source /path/to/bash-toys/source-all.sh
+zsh-vi-flash-find-setup
+```
+
+**Note**: zsh only. The file is sourced safely in bash (no-op).
+
 ## Neovim Integration
 
 ### nvim-parent-edit

--- a/sources/zsh-vi-flash-find.sh
+++ b/sources/zsh-vi-flash-find.sh
@@ -3,7 +3,7 @@
 # See ../doc/sources.md for description
 
 # ZSH only — skip silently in bash
-if [[ -z $ZSH_VERSION ]] ; then
+if [[ $ZSH_VERSION == '' ]] ; then
   return 0
 fi
 

--- a/sources/zsh-vi-flash-find.sh
+++ b/sources/zsh-vi-flash-find.sh
@@ -117,11 +117,12 @@ function _bash_toys_flash_find_next_motion () {
   local last_widget="$5"
 
   local _is_our_widget=''
-  if [[ "$last_widget" =~ '^bash-toys::flash-find::(f|F|t|T)$' ]] ; then
+  if [[ $last_widget =~ '^bash-toys::flash-find::(f|F|t|T)$' ]] ; then
     _is_our_widget=1
   fi
 
-  if [[ -n $_is_our_widget ]] && \
+  if [[ $_is_our_widget != '' ]] && 
+
      [[ $_bash_toys_flash_find_last == "$widget_name" || $_bash_toys_flash_find_last == "$counterpart" ]] ; then
     if [[ $_bash_toys_flash_find_dir == "$native_dir" ]] ; then
       _bash_toys_flash_find_computed_motion='vi-repeat-find'

--- a/sources/zsh-vi-flash-find.sh
+++ b/sources/zsh-vi-flash-find.sh
@@ -175,7 +175,7 @@ function zsh-vi-flash-find-setup () {
   bindkey -M vicmd 't' bash-toys::flash-find::t
   bindkey -M vicmd 'T' bash-toys::flash-find::T
 
-  if [[ -z $_bash_toys_flash_find_hooks_registered ]] ; then
+  if [[ $_bash_toys_flash_find_hooks_registered == '' ]] ; then
     autoload -Uz add-zle-hook-widget
     add-zle-hook-widget keymap-select _bash_toys_flash_find_keymap_select
     add-zle-hook-widget line-init     _bash_toys_flash_find_line_init

--- a/sources/zsh-vi-flash-find.sh
+++ b/sources/zsh-vi-flash-find.sh
@@ -149,8 +149,8 @@ function zsh-vi-flash-find-setup () {
   bindkey -M vicmd 'T' bash-toys::flash-find::T
 
   autoload -Uz add-zle-hook-widget
-  add-zle-hook-widget keymap-select _bash_toys_flash_find_keymap_select
-  add-zle-hook-widget line-init     _bash_toys_flash_find_line_init
+add-zle-hook-widget -n keymap-select _bash_toys_flash_find_keymap_select
+add-zle-hook-widget -n line-init     _bash_toys_flash_find_line_init
 }
 
 # https://github.com/aiya000/bash-toys

--- a/sources/zsh-vi-flash-find.sh
+++ b/sources/zsh-vi-flash-find.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+# See ../doc/sources.md for description
+
+# ZSH only — skip silently in bash
+if [[ -z $ZSH_VERSION ]] ; then
+  return 0
+fi
+
+function bash-toys::help::zsh-vi-flash-find () {
+  cat << 'EOF'
+zsh-vi-flash-find - Vim-style f/F/t/T with flash.nvim-compatible repeat key
+
+Usage:
+  zsh-vi-flash-find-setup
+  zsh-vi-flash-find-setup -h | --help
+
+Description:
+  Binds f, F, t, T in zsh vi-mode so that pressing the same key again
+  repeats the motion (like `;` in Vim), matching flash.nvim's behavior.
+  Pressing the counterpart key (f after F, or F after f) reverses direction
+  (like `,` in Vim).
+
+  Without this plugin:
+    fa;;;   (standard zsh: `;` to repeat)
+
+  With this plugin:
+    fafff   (same as fa;;; -- f repeats forward)
+    FaFFF   (same as Fa;;; -- F repeats backward)
+    faFF    (fa forward, then FF reverses -- like fa,, in standard vi)
+    FaFff   (Fa backward, then ff reverses forward)
+
+  The first keypress acts as the original vi motion.
+  Subsequent consecutive keypresses of the same key repeat the find.
+  The counterpart key reverses direction.
+  State resets when entering insert mode or starting a new command line.
+
+  Keys bound:
+    f   vi-find-next-char      (repeat forward with f; reverse with F)
+    F   vi-find-prev-char      (repeat backward with F; reverse with f)
+    t   vi-find-next-char-skip (repeat forward with t; reverse with T)
+    T   vi-find-prev-char-skip (repeat backward with T; reverse with t)
+
+  Note: This is a zsh-only feature (requires ZLE). The function is a no-op
+  in bash.
+
+Setup:
+  Call zsh-vi-flash-find-setup in your .zshrc after entering vi mode:
+
+    bindkey -v
+    source /path/to/bash-toys/sources/zsh-vi-flash-find.sh
+    zsh-vi-flash-find-setup
+
+Examples:
+  # In .zshrc
+  bindkey -v
+  zsh-vi-flash-find-setup
+
+  # Then in the shell (vi normal mode):
+  # fafff  =>  moves to next 'a', then repeats twice (like fa;;)
+  # tbtb   =>  moves before next 'b', then repeats (like tbt;)
+  # fafFF  =>  fa forward, f forward, FF backward twice
+EOF
+}
+
+# _bash_toys_flash_find_last: widget name of the last f/F/t/T press; '' = no active search
+# _bash_toys_flash_find_dir:  direction ZLE internally stored at the last new search
+#   'forward'  -- vi-repeat-find goes forward  (after vi-find-next-char / vi-find-next-char-skip)
+#   'backward' -- vi-repeat-find goes backward (after vi-find-prev-char / vi-find-prev-char-skip)
+# Both are reset on keymap change away from vicmd and at the start of each new command line.
+_bash_toys_flash_find_last=''
+_bash_toys_flash_find_dir=''
+
+function _bash_toys_flash_find_reset () {
+  _bash_toys_flash_find_last=''
+  _bash_toys_flash_find_dir=''
+}
+
+# Called by add-zle-hook-widget keymap-select; $KEYMAP is the new keymap.
+function _bash_toys_flash_find_keymap_select () {
+  [[ $KEYMAP != vicmd ]] && _bash_toys_flash_find_reset
+}
+
+# Called by add-zle-hook-widget line-init; fires at the start of each new command line.
+function _bash_toys_flash_find_line_init () {
+  _bash_toys_flash_find_reset
+}
+
+# $1: widget_name -- this widget's id,      e.g. 'bash-toys::flash-find::f'
+# $2: zle_motion  -- new-search motion,     e.g. 'vi-find-next-char'
+# $3: native_dir  -- 'forward' or 'backward' (the direction this key represents)
+# $4: counterpart -- the paired widget,     e.g. 'bash-toys::flash-find::F'
+#
+# Repeat/reverse logic:
+#   same key or counterpart key pressed -> choose vi-repeat-find vs vi-rev-repeat-find
+#   based on whether ZLE's stored direction (_bash_toys_flash_find_dir) matches native_dir.
+#   If they match  -> vi-repeat-find    (ZLE goes the same way as this key's native direction)
+#   If they differ -> vi-rev-repeat-find (ZLE goes the opposite way)
+function _bash_toys_flash_find_widget () {
+  local widget_name="$1"
+  local zle_motion="$2"
+  local native_dir="$3"
+  local counterpart="$4"
+
+  if [[ $_bash_toys_flash_find_last == "$widget_name" || $_bash_toys_flash_find_last == "$counterpart" ]] ; then
+    if [[ $_bash_toys_flash_find_dir == "$native_dir" ]] ; then
+      zle vi-repeat-find
+    else
+      zle vi-rev-repeat-find
+    fi
+  else
+    zle "$zle_motion"
+    _bash_toys_flash_find_dir="$native_dir"
+  fi
+
+  _bash_toys_flash_find_last="$widget_name"
+}
+
+function _bash_toys_flash_find_f () {
+  _bash_toys_flash_find_widget 'bash-toys::flash-find::f' 'vi-find-next-char'      'forward'  'bash-toys::flash-find::F'
+}
+
+function _bash_toys_flash_find_F () {
+  _bash_toys_flash_find_widget 'bash-toys::flash-find::F' 'vi-find-prev-char'      'backward' 'bash-toys::flash-find::f'
+}
+
+function _bash_toys_flash_find_t () {
+  _bash_toys_flash_find_widget 'bash-toys::flash-find::t' 'vi-find-next-char-skip' 'forward'  'bash-toys::flash-find::T'
+}
+
+function _bash_toys_flash_find_T () {
+  _bash_toys_flash_find_widget 'bash-toys::flash-find::T' 'vi-find-prev-char-skip' 'backward' 'bash-toys::flash-find::t'
+}
+
+function zsh-vi-flash-find-setup () {
+  if [[ $1 == -h || $1 == --help ]] ; then
+    bash-toys::help::zsh-vi-flash-find
+    return 0
+  fi
+
+  zle -N bash-toys::flash-find::f _bash_toys_flash_find_f
+  zle -N bash-toys::flash-find::F _bash_toys_flash_find_F
+  zle -N bash-toys::flash-find::t _bash_toys_flash_find_t
+  zle -N bash-toys::flash-find::T _bash_toys_flash_find_T
+
+  bindkey -M vicmd 'f' bash-toys::flash-find::f
+  bindkey -M vicmd 'F' bash-toys::flash-find::F
+  bindkey -M vicmd 't' bash-toys::flash-find::t
+  bindkey -M vicmd 'T' bash-toys::flash-find::T
+
+  autoload -Uz add-zle-hook-widget
+  add-zle-hook-widget keymap-select _bash_toys_flash_find_keymap_select
+  add-zle-hook-widget line-init     _bash_toys_flash_find_line_init
+}
+
+# https://github.com/aiya000/bash-toys
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2025- aiya000
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.

--- a/sources/zsh-vi-flash-find.sh
+++ b/sources/zsh-vi-flash-find.sh
@@ -34,6 +34,7 @@ Description:
   Subsequent consecutive keypresses of the same key repeat the find.
   The counterpart key reverses direction.
   State resets when entering insert mode or starting a new command line.
+  Any non-f/F/t/T keypress in between also resets (starts a new search).
 
   Keys bound:
     f   vi-find-next-char      (repeat forward with f; reverse with F)
@@ -60,16 +61,19 @@ Examples:
   # fafff  =>  moves to next 'a', then repeats twice (like fa;;)
   # tbtb   =>  moves before next 'b', then repeats (like tbt;)
   # fafFF  =>  fa forward, f forward, FF backward twice
+  # faf0f  =>  fa forward, repeat once, 0 resets sequence, next f starts fresh search
 EOF
 }
 
-# _bash_toys_flash_find_last: widget name of the last f/F/t/T press; '' = no active search
-# _bash_toys_flash_find_dir:  direction ZLE internally stored at the last new search
+# _bash_toys_flash_find_last:            widget name of the last f/F/t/T press; '' = no active search
+# _bash_toys_flash_find_dir:             direction stored at the last new search
 #   'forward'  -- vi-repeat-find goes forward  (after vi-find-next-char / vi-find-next-char-skip)
 #   'backward' -- vi-repeat-find goes backward (after vi-find-prev-char / vi-find-prev-char-skip)
-# Both are reset on keymap change away from vicmd and at the start of each new command line.
+# _bash_toys_flash_find_computed_motion: output of _bash_toys_flash_find_next_motion; the ZLE motion to call
+# Both _last and _dir are reset on keymap change away from vicmd and at the start of each new command line.
 _bash_toys_flash_find_last=''
 _bash_toys_flash_find_dir=''
+_bash_toys_flash_find_computed_motion=''
 _bash_toys_flash_find_hooks_registered=''
 
 function _bash_toys_flash_find_reset () {
@@ -87,34 +91,55 @@ function _bash_toys_flash_find_line_init () {
   _bash_toys_flash_find_reset
 }
 
+# Pure state-transition function (no ZLE calls). Testable without an interactive ZLE session.
+# Sets _bash_toys_flash_find_computed_motion to the ZLE motion that should be invoked.
+# Updates _bash_toys_flash_find_last and _bash_toys_flash_find_dir as side effects.
+#
 # $1: widget_name -- this widget's id,      e.g. 'bash-toys::flash-find::f'
 # $2: zle_motion  -- new-search motion,     e.g. 'vi-find-next-char'
 # $3: native_dir  -- 'forward' or 'backward' (the direction this key represents)
 # $4: counterpart -- the paired widget,     e.g. 'bash-toys::flash-find::F'
+# $5: last_widget -- the ZLE widget executed immediately before this one
+#                    (pass $LASTWIDGET in ZLE context; pass '' or a non-ours value in tests)
 #
 # Repeat/reverse logic:
-#   same key or counterpart key pressed -> choose vi-repeat-find vs vi-rev-repeat-find
-#   based on whether ZLE's stored direction (_bash_toys_flash_find_dir) matches native_dir.
-#   If they match  -> vi-repeat-find    (ZLE goes the same way as this key's native direction)
-#   If they differ -> vi-rev-repeat-find (ZLE goes the opposite way)
-function _bash_toys_flash_find_widget () {
+#   If $5 (last_widget) is one of our f/F/t/T widgets AND _last matches this widget or its
+#   counterpart, we are in a repeat/reverse sequence:
+#     _dir == native_dir  -> vi-repeat-find    (same direction as this key)
+#     _dir != native_dir  -> vi-rev-repeat-find (opposite direction)
+#   If last_widget is NOT one of ours (e.g. '0' was pressed), treat as a new search
+#   regardless of _last, so that non-f/F/t/T keys interrupt the sequence.
+function _bash_toys_flash_find_next_motion () {
   local widget_name="$1"
   local zle_motion="$2"
   local native_dir="$3"
   local counterpart="$4"
+  local last_widget="$5"
 
-  if [[ $_bash_toys_flash_find_last == "$widget_name" || $_bash_toys_flash_find_last == "$counterpart" ]] ; then
+  local _is_our_widget=''
+  if [[ "$last_widget" =~ '^bash-toys::flash-find::(f|F|t|T)$' ]] ; then
+    _is_our_widget=1
+  fi
+
+  if [[ -n $_is_our_widget ]] && \
+     [[ $_bash_toys_flash_find_last == "$widget_name" || $_bash_toys_flash_find_last == "$counterpart" ]] ; then
     if [[ $_bash_toys_flash_find_dir == "$native_dir" ]] ; then
-      zle vi-repeat-find
+      _bash_toys_flash_find_computed_motion='vi-repeat-find'
     else
-      zle vi-rev-repeat-find
+      _bash_toys_flash_find_computed_motion='vi-rev-repeat-find'
     fi
   else
-    zle "$zle_motion"
+    _bash_toys_flash_find_computed_motion="$zle_motion"
     _bash_toys_flash_find_dir="$native_dir"
   fi
 
   _bash_toys_flash_find_last="$widget_name"
+}
+
+# ZLE widget wrapper: calls the pure logic function then invokes the computed ZLE motion.
+function _bash_toys_flash_find_widget () {
+  _bash_toys_flash_find_next_motion "$1" "$2" "$3" "$4" "$LASTWIDGET"
+  zle "$_bash_toys_flash_find_computed_motion"
 }
 
 function _bash_toys_flash_find_f () {

--- a/sources/zsh-vi-flash-find.sh
+++ b/sources/zsh-vi-flash-find.sh
@@ -70,6 +70,7 @@ EOF
 # Both are reset on keymap change away from vicmd and at the start of each new command line.
 _bash_toys_flash_find_last=''
 _bash_toys_flash_find_dir=''
+_bash_toys_flash_find_hooks_registered=''
 
 function _bash_toys_flash_find_reset () {
   _bash_toys_flash_find_last=''
@@ -148,9 +149,12 @@ function zsh-vi-flash-find-setup () {
   bindkey -M vicmd 't' bash-toys::flash-find::t
   bindkey -M vicmd 'T' bash-toys::flash-find::T
 
-  autoload -Uz add-zle-hook-widget
-add-zle-hook-widget -n keymap-select _bash_toys_flash_find_keymap_select
-add-zle-hook-widget -n line-init     _bash_toys_flash_find_line_init
+  if [[ -z $_bash_toys_flash_find_hooks_registered ]] ; then
+    autoload -Uz add-zle-hook-widget
+    add-zle-hook-widget keymap-select _bash_toys_flash_find_keymap_select
+    add-zle-hook-widget line-init     _bash_toys_flash_find_line_init
+    _bash_toys_flash_find_hooks_registered=1
+  fi
 }
 
 # https://github.com/aiya000/bash-toys

--- a/test/zsh-vi-flash-find.bats
+++ b/test/zsh-vi-flash-find.bats
@@ -3,11 +3,36 @@
 # shellcheck disable=SC2016
 
 # ZLE widget behavior requires an interactive zsh session and cannot be tested here.
-# These tests verify that the source file loads safely and help text works.
+# _bash_toys_flash_find_next_motion() is pure (no ZLE calls) and is tested below.
 
 setup() {
   export PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
 }
+
+# Helper: source the plugin and call _bash_toys_flash_find_next_motion, then print
+# the computed motion.
+# Usage: run_next_motion <widget_name> <zle_motion> <native_dir> <counterpart> <last_widget>
+# Prints _bash_toys_flash_find_computed_motion.
+ZSH_NEXT_MOTION_HELPER='
+  source ./sources/zsh-vi-flash-find.sh
+
+  function run_sequence () {
+    local args
+    args=("$@")
+    local i=1
+    while (( i <= ${#args[@]} )); do
+      local widget="${args[$i]}"  ; (( i++ ))
+      local motion="${args[$i]}"  ; (( i++ ))
+      local dir="${args[$i]}"     ; (( i++ ))
+      local counter="${args[$i]}" ; (( i++ ))
+      local last="${args[$i]}"    ; (( i++ ))
+      _bash_toys_flash_find_next_motion "$widget" "$motion" "$dir" "$counter" "$last"
+    done
+    echo "$_bash_toys_flash_find_computed_motion"
+  }
+'
+
+# ─── help ─────────────────────────────────────────────────────────────────────
 
 @test '`zsh-vi-flash-find-setup --help` should show help message' {
   run zsh -c 'source ./source-all.sh && zsh-vi-flash-find-setup --help'
@@ -24,4 +49,208 @@ setup() {
 @test 'sourcing zsh-vi-flash-find.sh in bash should be a no-op' {
   run bash -c 'source ./sources/zsh-vi-flash-find.sh && type zsh-vi-flash-find-setup 2>&1; echo "exit:$?"'
   expects "$output" to_match 'not found|no zsh-vi-flash-find-setup'
+}
+
+# ─── first keypress: always a new search ──────────────────────────────────────
+
+@test 'first f: should call vi-find-next-char' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" ""
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-find-next-char'
+}
+
+@test 'first F: should call vi-find-prev-char' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::F" "vi-find-prev-char" "backward" "bash-toys::flash-find::f" ""
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-find-prev-char'
+}
+
+@test 'first t: should call vi-find-next-char-skip' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::t" "vi-find-next-char-skip" "forward" "bash-toys::flash-find::T" ""
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-find-next-char-skip'
+}
+
+@test 'first T: should call vi-find-prev-char-skip' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::T" "vi-find-prev-char-skip" "backward" "bash-toys::flash-find::t" ""
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-find-prev-char-skip'
+}
+
+# ─── same key repeat (fa → ff → ff) ───────────────────────────────────────────
+
+@test 'ff (second f after f): should vi-repeat-find' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "" \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "bash-toys::flash-find::f"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-repeat-find'
+}
+
+@test 'FF (second F after F): should vi-repeat-find' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::F" "vi-find-prev-char" "backward" "bash-toys::flash-find::f" "" \
+      "bash-toys::flash-find::F" "vi-find-prev-char" "backward" "bash-toys::flash-find::f" "bash-toys::flash-find::F"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-repeat-find'
+}
+
+@test 'tt (second t after t): should vi-repeat-find' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::t" "vi-find-next-char-skip" "forward" "bash-toys::flash-find::T" "" \
+      "bash-toys::flash-find::t" "vi-find-next-char-skip" "forward" "bash-toys::flash-find::T" "bash-toys::flash-find::t"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-repeat-find'
+}
+
+@test 'TT (second T after T): should vi-repeat-find' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::T" "vi-find-prev-char-skip" "backward" "bash-toys::flash-find::t" "" \
+      "bash-toys::flash-find::T" "vi-find-prev-char-skip" "backward" "bash-toys::flash-find::t" "bash-toys::flash-find::T"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-repeat-find'
+}
+
+# ─── counterpart key reverse (fa → FF) ────────────────────────────────────────
+
+@test 'fF (F after f): should vi-rev-repeat-find' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "" \
+      "bash-toys::flash-find::F" "vi-find-prev-char" "backward" "bash-toys::flash-find::f" "bash-toys::flash-find::f"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-rev-repeat-find'
+}
+
+@test 'Ff (f after F): should vi-rev-repeat-find' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::F" "vi-find-prev-char" "backward" "bash-toys::flash-find::f" "" \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "bash-toys::flash-find::F"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-rev-repeat-find'
+}
+
+@test 'tT (T after t): should vi-rev-repeat-find' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::t" "vi-find-next-char-skip" "forward" "bash-toys::flash-find::T" "" \
+      "bash-toys::flash-find::T" "vi-find-prev-char-skip" "backward" "bash-toys::flash-find::t" "bash-toys::flash-find::t"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-rev-repeat-find'
+}
+
+@test 'Tt (t after T): should vi-rev-repeat-find' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::T" "vi-find-prev-char-skip" "backward" "bash-toys::flash-find::t" "" \
+      "bash-toys::flash-find::t" "vi-find-next-char-skip" "forward" "bash-toys::flash-find::T" "bash-toys::flash-find::T"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-rev-repeat-find'
+}
+
+# ─── multi-step sequences ──────────────────────────────────────────────────────
+
+@test 'faf followed by ff: both should vi-repeat-find' {
+  # faf = new search, then f (repeat), then f (repeat again)
+  # We test the third f here
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "" \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "bash-toys::flash-find::f" \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "bash-toys::flash-find::f"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-repeat-find'
+}
+
+@test 'faf followed by FF: should vi-rev-repeat-find (fafF bug fix)' {
+  # faf = new search + repeat; next F must reverse not forward
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "" \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "bash-toys::flash-find::f" \
+      "bash-toys::flash-find::F" "vi-find-prev-char" "backward" "bash-toys::flash-find::f" "bash-toys::flash-find::f"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-rev-repeat-find'
+}
+
+@test 'fafFF: second F should also vi-rev-repeat-find' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "" \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "bash-toys::flash-find::f" \
+      "bash-toys::flash-find::F" "vi-find-prev-char" "backward" "bash-toys::flash-find::f" "bash-toys::flash-find::f" \
+      "bash-toys::flash-find::F" "vi-find-prev-char" "backward" "bash-toys::flash-find::f" "bash-toys::flash-find::F"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-rev-repeat-find'
+}
+
+# ─── non-f/F/t/T key interrupts sequence ──────────────────────────────────────
+
+@test 'f after 0 (non-find widget): should start a new search' {
+  # Sequence: fa (new), then 0 pressed (non-ours), then f again
+  # last_widget for the second f is '0' (not one of ours) -> new search
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "" \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "digit-or-beginning-of-line"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-find-next-char'
+}
+
+@test 'F after non-find widget: should start a new search' {
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::F" "vi-find-prev-char" "backward" "bash-toys::flash-find::f" "" \
+      "bash-toys::flash-find::F" "vi-find-prev-char" "backward" "bash-toys::flash-find::f" "vi-backward-char"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-find-prev-char'
+}
+
+# ─── regression: faf then 0f (0 interrupts sequence) ─────────────────────────
+# Bug: in the original implementation _bash_toys_flash_find_last was never cleared
+# by non-f/F/t/T widgets, so pressing 0 then f would still call vi-repeat-find.
+# Fixed by checking $LASTWIDGET: if the previous widget is not one of ours, reset.
+
+@test 'faf then 0f: f after 0 should start a new search (not repeat)' {
+  # Step1: fa  (new search, last_widget='')
+  # Step2: f   (repeat,     last_widget='bash-toys::flash-find::f')
+  # Step3: f   (0 was pressed between steps, last_widget='vi-digit-or-beginning-of-line') -> new search
+  run zsh --no-rcs -c "$ZSH_NEXT_MOTION_HELPER"'
+    run_sequence \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "" \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "bash-toys::flash-find::f" \
+      "bash-toys::flash-find::f" "vi-find-next-char" "forward" "bash-toys::flash-find::F" "vi-digit-or-beginning-of-line"
+  '
+  expects "$status" to_be 0
+  expects "$output" to_equal 'vi-find-next-char'
 }

--- a/test/zsh-vi-flash-find.bats
+++ b/test/zsh-vi-flash-find.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+# shellcheck disable=SC2016
+
+# ZLE widget behavior requires an interactive zsh session and cannot be tested here.
+# These tests verify that the source file loads safely and help text works.
+
+setup() {
+  export PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
+}
+
+@test '`zsh-vi-flash-find-setup --help` should show help message' {
+  run zsh -c 'source ./source-all.sh && zsh-vi-flash-find-setup --help'
+  expects "$status" to_be 0
+  expects "${lines[0]}" to_match '^zsh-vi-flash-find - '
+}
+
+@test '`zsh-vi-flash-find-setup -h` should show help message' {
+  run zsh -c 'source ./source-all.sh && zsh-vi-flash-find-setup -h'
+  expects "$status" to_be 0
+  expects "${lines[0]}" to_match '^zsh-vi-flash-find - '
+}
+
+@test 'sourcing zsh-vi-flash-find.sh in bash should be a no-op' {
+  run bash -c 'source ./sources/zsh-vi-flash-find.sh && type zsh-vi-flash-find-setup 2>&1; echo "exit:$?"'
+  expects "$output" to_match 'not found|no zsh-vi-flash-find-setup'
+}


### PR DESCRIPTION
## Summary

- Add `zsh-vi-flash-find` source plugin: flash.nvim-compatible `f`/`F`/`t`/`T` repeat for zsh vi-mode
- Pressing the same key again repeats the find (like `;`); pressing the counterpart key reverses direction (like `,`)
- State resets automatically on insert-mode entry and at the start of each new command line

## Changes

- `sources/zsh-vi-flash-find.sh`: new ZLE widget plugin
  - Binds `f`, `F`, `t`, `T` in vicmd keymap via `zsh-vi-flash-find-setup`
  - Tracks last pressed widget and the ZLE-internal search direction (`_bash_toys_flash_find_dir`) to choose between `vi-repeat-find` and `vi-rev-repeat-find`
  - Registers `keymap-select` and `line-init` ZLE hooks via `add-zle-hook-widget` to reset state on insert-mode entry and new command line
  - zsh-only; silently no-ops in bash
- `test/zsh-vi-flash-find.bats`: smoke tests for `--help`/`-h` and bash no-op
- `doc/sources.md`: document new plugin under "ZSH Vi-Mode" section